### PR TITLE
temporary fix: install silan from unofficial repo. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,12 @@ RUN cd /opt && curl -s -O -L https://dl.google.com/go/go1.10.1.linux-amd64.tar.g
 RUN apt-get remove -y postgresql-9.5 rabbitmq-server icecast2
 RUN apt-get clean
 
+RUN export DEBIAN_FRONTEND=noninteractive && \
+ wget -qO- http://download.opensuse.org/repositories/home:/hairmare:/silan/Debian_7.0/Release.key   | apt-key add -  && \
+echo 'deb http://download.opensuse.org/repositories/home:/hairmare:/silan/xUbuntu_16.04 ./'   > /etc/apt/sources.list.d/hairmare_silan.list  && \
+apt-get update  && \
+apt-get install silan
+
 COPY bootstrap/entrypoint.sh /opt/libretime/entrypoint.sh
 COPY bootstrap/firstrun.sh /opt/libretime/firstrun.sh
 COPY config/supervisor-minimal.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
a temporary fix for https://github.com/ned-kelly/docker-multicontainer-libretime/issues/4

@hairmare has explicitly stated that he does not support this repo.

a better long term solution would be to use ubuntu bionic with php to 7.1. this could be the route we take for the single container repo under the LibreTime organization. see (https://github.com/LibreTime/libretime/issues/580#issuecomment-442271470)

see also https://github.com/LibreTime/libretime/wiki/Silan-Installation